### PR TITLE
Allow setting debug mode as CLI argument

### DIFF
--- a/ovn-event-exporter.py
+++ b/ovn-event-exporter.py
@@ -44,6 +44,8 @@ parser.add_argument('--bind_port', type=int, default=9000, help="Metrics exposin
                     "TCP port")
 parser.add_argument('--timeout', type=int, default=30, help="OVS DB connection "
                     "timeout")
+parser.add_argument('--debug', default=False, action='store_true', help="Set "
+                    "logging level to DEBUG")
 
 
 class NotificationBackend(object):
@@ -155,6 +157,11 @@ def signal_handler(signum, frame):
 
 if __name__ == "__main__":
     args = parser.parse_args()
+
+    if args.debug:
+        logger.setLevel(logging.DEBUG)
+        logger.debug("Logging level set to DEBUG")
+
     if not bool(args.sbdb) ^ bool(args.nbdb):
         logger.error('Only NBDB or SBDB usage possible. --nbdb and --sbdb '
                      'parameter cannot be use together')

--- a/ovn-event-exporter.py
+++ b/ovn-event-exporter.py
@@ -162,6 +162,8 @@ if __name__ == "__main__":
         logger.setLevel(logging.DEBUG)
         logger.debug("Logging level set to DEBUG")
 
+    logger.debug('Provided arguments: %s' % args)
+
     if not bool(args.sbdb) ^ bool(args.nbdb):
         logger.error('Only NBDB or SBDB usage possible. --nbdb and --sbdb '
                      'parameter cannot be use together')


### PR DESCRIPTION
Hi,
There are some debug level logs already declared in code, but not readable without manual code modification. This change allows user to enable debug mode with argument. It also lists all provided arguments, for easier debugging. Maybe more debug messages could be added in future?
Thanks,
Franek