### PR TITLE
Stop all threads when SIGTERM is sent

### DIFF
--- a/ovn-event-exporter.py
+++ b/ovn-event-exporter.py
@@ -203,3 +203,5 @@ if __name__ == "__main__":
             httpd.set_app(null_app)
 
     timer.cancel()
+    httpd.shutdown()
+    ovs.connection.stop()


### PR DESCRIPTION
Hi,
Both `httpd`, and `ovs` threads are not stopped gracefully with SIGTERM. This change fixes this behaviour. 

Credits to @ictud for helping with debug.

Thanks!